### PR TITLE
fixes #8, pass (first) exception from event callback

### DIFF
--- a/rw/event.py
+++ b/rw/event.py
@@ -20,13 +20,16 @@ Signal
 """
 from __future__ import absolute_import, division, print_function, with_statement
 
-import traceback
-
 from tornado import gen
-import rw.scope
 
 
 class Event(set):
+    """
+    A simple within-process pub/sub event system.
+
+    If multiple callbacks are provided and raise exceptions,
+    the first detected exception is re-raised and all successive exceptions are ignored.
+    """
     def __init__(self, name, accumulator=None):
         super(Event, self).__init__()
         self.name = name

--- a/rw/event.py
+++ b/rw/event.py
@@ -26,15 +26,6 @@ from tornado import gen
 import rw.scope
 
 
-class EventException(Exception):
-    def __init__(self, exceptions):
-        self.exceptions = exceptions
-        message = '{} exceptions encountered:\n'.format(len(exceptions))
-        for func, e in exceptions:
-            message += '{}:\n{}'.format(func, e)
-        Exception.__init__(self, ''.join(message))
-
-
 class Event(set):
     def __init__(self, name, accumulator=None):
         super(Event, self).__init__()
@@ -43,38 +34,24 @@ class Event(set):
 
     @gen.coroutine
     def __call__(self, *args, **kwargs):
-        scope = rw.scope.get_current_scope()
-        rw_tracing = scope.get('rw_trace', None) if scope else None
-
         re = []
-        exceptions = []
         futures = []
         for func in self:
-            try:
-                result = func(*args, **kwargs)
-                if isinstance(result, gen.Future):
-                    # we are not waiting for future objects result here
-                    # so they evaluate in parallel
-                    futures.append((func, result))
-                else:
-                    re.append(result)
-            except Exception:
-                exceptions.append((func, traceback.format_exc()))
+            result = func(*args, **kwargs)
+            if isinstance(result, gen.Future):
+                # we are not waiting for future objects result here
+                # so they evaluate in parallel
+                futures.append((func, result))
+            else:
+                re.append(result)
 
         # wait for results
         for func, future in futures:
-            try:
-                if not future.done():
-                    yield future
-                re.append(future.result())
+            if not future.done():
+                yield future
+            re.append(future.result())
 
-            except Exception:
-                exceptions.append((func, traceback.format_exc()))
-
-        if exceptions:
-            raise EventException(exceptions)
-
-        # apply accumolator
+        # apply accumulator
         if self.accumulator:
             re = self.accumulator(re)
 

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -23,17 +23,8 @@ class MyTestCase(tornado.testing.AsyncTestCase):
         def fail():
             1 / 0
 
-        with pytest.raises(rw.event.EventException):
+        with pytest.raises(ZeroDivisionError):
             yield MY_EVENT()
-
-        try:
-            yield MY_EVENT()
-            assert False  # this line should never be reached
-        except rw.event.EventException as e:
-            # the original traceback should be get printed
-            assert 'in fail' in str(e)  # function name of the actual exception
-            assert '1 / 0' in str(e)  # the source line of the exception
-            assert 'ZeroDivisionError' in str(e)
 
     @tornado.testing.gen_test
     def test_event_listener(self):
@@ -87,14 +78,5 @@ class MyTestCase(tornado.testing.AsyncTestCase):
         MY_EVENT = rw.event.Event('MY_EVENT')
         MY_EVENT.add(something_lazy_failing)
 
-        with pytest.raises(rw.event.EventException):
+        with pytest.raises(ZeroDivisionError):
             yield MY_EVENT()
-
-        try:
-            yield MY_EVENT()
-            assert False  # this line should never be reached
-        except rw.event.EventException as e:
-            # the original traceback should be get printed
-            assert 'in something_lazy_failing' in str(e)  # function name of the actual exception
-            assert '1 / 0' in str(e)  # the source line of the exception
-            assert 'ZeroDivisionError' in str(e)


### PR DESCRIPTION
This basically removes all special exception handling from in events.
As a result, the first recognized exception should be thrown, ignoring all others.