### PR TITLE
allow for python3 typehints on injected args

### DIFF
--- a/rw/scope.py
+++ b/rw/scope.py
@@ -144,7 +144,10 @@ def get(key, default=NOT_PROVIDED):
 
 def inject(fn):
     fn_inspect = getattr(fn, '_rw_wrapped_function', fn)
-    arg_spec = inspect.getargspec(fn_inspect)
+    getargspec = inspect.getargspec
+    if sys.version_info >= (3, 0):
+        getargspec = inspect.getfullargspec
+    arg_spec = getargspec(fn_inspect)
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):

--- a/test/scope_py3.py
+++ b/test/scope_py3.py
@@ -1,0 +1,13 @@
+import rw.scope
+
+
+def test_python3_typehinted_injection():
+    scope = rw.scope.Scope()
+    scope['some_static_value'] = 42
+
+    @rw.scope.inject
+    def bar(some_static_value: int):
+        return some_static_value
+
+    with scope():
+        assert bar() == 42

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function, with_statement
 
 import pytest
+import sys
 from tornado import concurrent
 
 import tornado.gen
@@ -264,3 +265,9 @@ class ConcurrencyTest(tornado.testing.AsyncTestCase):
 
         self.lock_b.set_result(None)
         assert (yield future_b) == 'b'
+
+
+if sys.version_info >= (3, 0):
+    def test_scope_with_hint():
+        from test.scope_py3 import test_python3_typehinted_injection
+        test_python3_typehinted_injection()


### PR DESCRIPTION
the test says it:
```PYTHON
@rw.scope.inject
def bar(some_static_value: int):
    return some_static_value
```

This is not possible with getargspec
> ValueError: Function has keyword-only arguments or annotations, use getfullargspec() API which can support them